### PR TITLE
fixed instructions - typo

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -172,7 +172,7 @@ of a metrics report.
 1. Get your Target server URL from the CloudFormation outputs from the stack you created earlier
 1. In a second console tab (leave the agent running), run "ab" tool, which will generate HTTP traffic from your "device" to the target server
    ```bash
-      #Note: the trailing space is necessary here:
+      #Note: the trailing slash is necessary here:
       ab -n 20000 http://YOUR_TARGET_INSTANCE_URL/
    ```
 


### PR DESCRIPTION
*Issue #, if available:* None - was in AWS Reinvent workshop, found a typo in the instructions.

*Description of changes:*
Fixed typo for 'should have a trailing slash'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
